### PR TITLE
Added updates to allow this extension to work on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ server/src/main/cfml/testbox/
 server/src/main/cfml/cfscriptme/
 server/src/main/cfml/lsp/docs/types.ts
 server/src/main/cfml/cfformat_old/
+
+resources/lucee_lsp-1.0-all.jar
+server/src/main/resources/lucee_lsp.war

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -207,7 +207,6 @@ export async function activate(context: ExtensionContext) {
           `-Dlucee.lsp.port=${lspPort}`,
           `-Dlucee.server.port=${serverPort}`,
           /* Added support for Windows */
-          // `-Dlucee.server.wardir=/tmp`,
           `-Dlucee.server.wardir=${os.tmpdir()}`,
           "-jar",
           lspjar,

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -21,6 +21,8 @@ import {
 } from "vscode-languageclient/node";
 import { Status, StatusBarEntry } from "./utils/status";
 
+import * as os from "os";
+
 const label = "CFML Formatter";
 let lspPort: number = 2089;
 let serverPort: number = 4000;
@@ -136,6 +138,14 @@ export async function activate(context: ExtensionContext) {
     connectionOptions: {
       maxRestartCount: 5,
     },
+    middleware: {
+        provideDocumentFormattingEdits: async (document, options, token, next) => {
+            const source = new vscode.CancellationTokenSource();
+            const result = await next(document, options, source.token);
+            source.dispose();
+            return result;
+        }
+    },
     synchronize: {
       // Notify the server about file changes to varioius config files contained in the workspace
       fileEvents: [
@@ -196,7 +206,9 @@ export async function activate(context: ExtensionContext) {
         luceeServer = await startServer(javaPath, [
           `-Dlucee.lsp.port=${lspPort}`,
           `-Dlucee.server.port=${serverPort}`,
-          `-Dlucee.server.wardir=/tmp`,
+          /* Added support for Windows */
+          // `-Dlucee.server.wardir=/tmp`,
+          `-Dlucee.server.wardir=${os.tmpdir()}`,
           "-jar",
           lspjar,
         ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cfml-formatter",
-  "version": "1.0.105",
+  "version": "1.0.106",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cfml-formatter",
-      "version": "1.0.105",
+      "version": "1.0.106",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Mark Drew",
   "preview": true,
   "license": "MIT",
-  "version": "1.0.105",
+  "version": "1.0.106",
   "publisher": "markdrew",
   "repository": {
     "type": "git",

--- a/server/build.xml
+++ b/server/build.xml
@@ -5,7 +5,10 @@
     <property name="dist.dir" location="dist" />
     <property name="war.output" location="${dist.dir}/lucee_lsp.war" />
     <!-- <property name="jar.output" location="${dist.dir}/my_app.jar" /> -->
-    <property name="maven.command" value="mvn" />
+    <!-- <property name="maven.command" value="mvn" /> -->
+    <condition property="maven.command" value="mvn.cmd" else="mvn">
+        <os family="windows"/>
+    </condition>
     <property name="build.dir" location="build" />
 
     <!-- Clean task -->

--- a/server/src/main/cfml/.cfformat.json
+++ b/server/src/main/cfml/.cfformat.json
@@ -1,4 +1,5 @@
 {
+    "alignment.consecutive.assignments": true,
     "strings.attributes.quote": "double",
     "strings.convertNestedQuotes": true,
     "strings.quote": "single",

--- a/server/src/main/cfml/cfformat/models/CFFormat.cfc
+++ b/server/src/main/cfml/cfformat/models/CFFormat.cfc
@@ -265,7 +265,6 @@ component accessors="true" {
     }
 
     function cftokensFile(cmd, fullFilePath) {
-        // var p = createObject('java', 'java.lang.ProcessBuilder').init([executable, cmd, fullFilePath]).start();
         /* Added support for Windows */
         var p = createObject('java', 'java.lang.ProcessBuilder')
         .init([executable, cmd, fullFilePath])

--- a/server/src/main/cfml/cfformat/models/CFFormat.cfc
+++ b/server/src/main/cfml/cfformat/models/CFFormat.cfc
@@ -265,7 +265,12 @@ component accessors="true" {
     }
 
     function cftokensFile(cmd, fullFilePath) {
-        var p = createObject('java', 'java.lang.ProcessBuilder').init([executable, cmd, fullFilePath]).start();
+        // var p = createObject('java', 'java.lang.ProcessBuilder').init([executable, cmd, fullFilePath]).start();
+        /* Added support for Windows */
+        var p = createObject('java', 'java.lang.ProcessBuilder')
+        .init([executable, cmd, fullFilePath])
+        .redirectErrorStream(true)
+        .start();
         var inputStreamReader = createObject('java', 'java.io.InputStreamReader').init(p.getInputStream(), 'utf-8');
         var bufferedReader = createObject('java', 'java.io.BufferedReader').init(inputStreamReader);
         var collector = createObject('java', 'java.util.stream.Collectors').joining(variables.lf);

--- a/server/src/main/cfml/lsp/LSPServer.cfc
+++ b/server/src/main/cfml/lsp/LSPServer.cfc
@@ -52,6 +52,7 @@ component accessors=true {
         // variables.pendingMessages[config.id] = config;
         // lspEndpoint.sendMessageToClient(config);
         // Store a log of pending messages to be fulfilled. 
+
         console.log('- Initializing LSP Server');
 
         variables.initilized = true;

--- a/server/src/main/cfml/lsp/TextDocumentStore.cfc
+++ b/server/src/main/cfml/lsp/TextDocumentStore.cfc
@@ -40,12 +40,6 @@ component accessors=true {
         var uri = textDocumentItem.getURI();
         var text = textDocumentItem.getText();
 
-        // write it
-        /* var fileHash = '/tmp/#hash(uri)#';
-        var fileExtension = lCase(listLast(uri, '.'));
-        var fileName = '#fileHash#.#fileExtension#';
-        fileWrite(fileName, text); */
-
         /* Added support for Windows */
         // write it
         var fileHash = '/tmp/#hash(uri)#';
@@ -54,27 +48,12 @@ component accessors=true {
         if (!directoryExists(expandPath('/tmp'))) {
             directoryCreate(expandPath('/tmp'));
         }
-        // fileWrite(fileName, text);
         /* Added support for Windows */
         fileWrite(fileName, text, 'utf-8');
 
         // Also need to check if we are formating during save.
 
         if (fileExtension == 'cfc' OR fileExtension == 'cfm' OR fileExtension == 'cfml') {
-            /* var tokens = cfformat.cftokensFile('tokenize', fileName);
-            var parsed = cfformat.cftokensFile('parse', fileName); */
-
-            /* Added support for Windows */
-            /** var tokens = cfformat.cftokensFile('tokenize', expandPath(fileName));
-            var parsed = cfformat.cftokensFile('parse', expandPath(fileName));
-
-            textDocumentItem.setTokens(tokens);
-            textDocumentItem.setParsed(parsed); **/
-
-            /* Added support for Windows */
-            //var parsed = cfformat.cftokensFile('parse', expandPath(fileName));
-
-            //textDocumentItem.setParsed(parsed);
 
             /* Added support for Windows */
             // removed cftokens calls - formatting will call these when needed

--- a/server/src/main/cfml/lsp/TextDocumentStore.cfc
+++ b/server/src/main/cfml/lsp/TextDocumentStore.cfc
@@ -41,19 +41,43 @@ component accessors=true {
         var text = textDocumentItem.getText();
 
         // write it
+        /* var fileHash = '/tmp/#hash(uri)#';
+        var fileExtension = lCase(listLast(uri, '.'));
+        var fileName = '#fileHash#.#fileExtension#';
+        fileWrite(fileName, text); */
+
+        /* Added support for Windows */
+        // write it
         var fileHash = '/tmp/#hash(uri)#';
         var fileExtension = lCase(listLast(uri, '.'));
         var fileName = '#fileHash#.#fileExtension#';
-        fileWrite(fileName, text);
+        if (!directoryExists(expandPath('/tmp'))) {
+            directoryCreate(expandPath('/tmp'));
+        }
+        // fileWrite(fileName, text);
+        /* Added support for Windows */
+        fileWrite(fileName, text, 'utf-8');
 
         // Also need to check if we are formating during save.
 
         if (fileExtension == 'cfc' OR fileExtension == 'cfm' OR fileExtension == 'cfml') {
-            var tokens = cfformat.cftokensFile('tokenize', fileName);
-            var parsed = cfformat.cftokensFile('parse', fileName);
+            /* var tokens = cfformat.cftokensFile('tokenize', fileName);
+            var parsed = cfformat.cftokensFile('parse', fileName); */
+
+            /* Added support for Windows */
+            /** var tokens = cfformat.cftokensFile('tokenize', expandPath(fileName));
+            var parsed = cfformat.cftokensFile('parse', expandPath(fileName));
 
             textDocumentItem.setTokens(tokens);
-            textDocumentItem.setParsed(parsed);
+            textDocumentItem.setParsed(parsed); **/
+
+            /* Added support for Windows */
+            //var parsed = cfformat.cftokensFile('parse', expandPath(fileName));
+
+            //textDocumentItem.setParsed(parsed);
+
+            /* Added support for Windows */
+            // removed cftokens calls - formatting will call these when needed
         }
 
         updateDocument(textDocumentItem);

--- a/server/src/main/cfml/lsp/methods/textDocument.cfc
+++ b/server/src/main/cfml/lsp/methods/textDocument.cfc
@@ -152,6 +152,7 @@ component accessors="true" {
     }
 
 
+    /* Added support for Windows */
     public struct function formatting(required struct message) {
         var theDoc = getTextDocumentStore().getDocument(arguments.message.params.textDocument.uri);
 
@@ -163,36 +164,22 @@ component accessors="true" {
                 'error': {'code': -32603, 'message': 'Document not found, try re-opening the file'}
             };
         }
-        var defaultSettingsPath = getConfigStore().getSettings();
-        // Have to save the file to disk and then run the formatter on it.
-        var extension = listLast(message.params.textDocument.uri, '.');
-        var filename = '/tmp/#hash(message.params.textDocument.uri)#.#extension#';
 
-        fileWrite(filename, theDoc);
         var settings = {};
         var rootURI = getConfigStore().getConfig().rootURI;
-
-        // All the findConfigFile stuff should be in one function, we should do finding and returning of the config.
         var loadSettings = findConfigFile(message.params.textDocument.uri, rootURI);
-
-
 
         if (len(loadSettings)) {
             showClientLog('info', 'Loading settings from ' & loadSettings);
-            var rawSettings = fileRead(loadSettings);
-            settings = deserializeJSON(rawSettings);
+            settings = deserializeJSON(fileRead(loadSettings));
         } else {
             showClientMessage('warning', 'No formatting settings found. Using Default');
             showClientLog('warning', 'No formatting settings found. Using Default');
         }
 
-
         try {
-            // console.log("Config Settings", settings);
-            var originalLines = getLines(theDoc);
-            var formattedDoc = getCFFormat().formatFile(filename, settings);
-            // Send a message to the client to let them know what we are formatting with
-            // getLSP('info', 'Formatting with settings');
+            var originalLines = getLines(theDoc.getText());
+            var formattedDoc = getCFFormat().formatText(theDoc.getText(), settings);
             var docname = listLast(arguments.message.params.textDocument.uri, '/');
             showClientMessage('info', 'Formatted #docname#');
             showClientLog('info', 'Formatted #docname#');
@@ -203,14 +190,13 @@ component accessors="true" {
                     {
                         'range': {
                             'start': {'line': 0, 'character': 0},
-                            'end': {'line': originalLines.len(), 'character': originalLines.last().len()}
+                            'end': {'line': originalLines.len(), 'character': originalLines.isEmpty() ? 0 : originalLines.last().len()}
                         },
                         'newText': formattedDoc
                     }
                 ]
             }
         } catch (ext) {
-            // Need to decorate with the file.
             var message = '#ext.message# in #message.params.textDocument.uri#';
             showClientMessage('error', message);
             showClientLog('error', message);
@@ -218,10 +204,6 @@ component accessors="true" {
                 return {'jsonrpc': '2.0', 'id': message.id, 'error': {'code': -32700, 'message': message, 'data': ext}}
             }
             return {'jsonrpc': '2.0', 'error': {'code': -32700, 'message': message, 'data': ext}}
-
-
-
-            // throw(ext);
         }
     }
 


### PR DESCRIPTION
Added updates to allow this extension to work on `Windows`:

### Files changed:

```
client/src/extension.ts
server/build.xml
server/src/main/cfml/.cfformat.json
server/src/main/cfml/cfformat/models/CFFormat.cfc
server/src/main/cfml/lsp/LSPServer.cfc
server/src/main/cfml/lsp/TextDocumentStore.cfc
server/src/main/cfml/lsp/methods/textDocument.cfc
```

### Original Bug Summary:

- [ ] Root cause — hardcoded /tmp path doesn't work on Windows

**Changes made:**

- [X] **extension.ts** — os.tmpdir() for cross-platform temp directory, middleware to prevent VSCode cancelling format requests
- [X] **build.xml** — mvn.cmd instead of mvn for Windows Maven
- [X] **TextDocumentStore.cfc** — directoryCreate, expandPath, UTF-8 encoding
- [X] **CFFormat.cfc** — redirectErrorStream(true) to capture cftokens errors
- [X] **textDocument.cfc** — formatText instead of formatFile, proper settings ordering
- [X] **.cfformat.json** — sensible default settings

### Run this test:

> test.cfm

```
<cfset scriptDir = '/'>
<cfset conciseHTMLWebPath = scriptDir & 'output/extracted_concise.html'/>
<cfset conciseCSSWebPath = scriptDir & 'output/extracted_concise.css'/>

<cfscript>
scriptDir = '/';
conciseHTMLWebPath = scriptDir & 'output/extracted_concise.html';
conciseCSSWebPath  = scriptDir & 'output/extracted_concise.css';
</cfscript>
```

In the settings for `Windows` you need to add full path:

```
Cfml-formatter: Default Config
The path to a default config file to if one is not defined in the workspace
C:\domains\some-local-repo\wwwroot\.cfformat.json

Cfml-formatter: Java Path
The path to the java executable to run the Language Server
C:\Program Files\Java\jdk-11\bin\java.exe
```

Here is my:

> C:\domains\some-local-repo\wwwroot\.cfformat.json

```
{
    "alignment.consecutive.assignments": true,
    "strings.attributes.quote": "double",
    "strings.convertNestedQuotes": true,
    "strings.quote": "single",
    "struct.empty_padding": false,
    "struct.multiline.comma_dangle": false,
    "struct.multiline.element_count": 4,
    "struct.multiline.leading_comma": false,
    "struct.multiline.leading_comma.padding": true,
    "struct.multiline.min_length": 60,
    "struct.padding": false,
    "struct.quote_keys": false,
    "struct.separator": ": ",
    "tags.lowercase": true,
    "array.empty_padding": false,
    "array.multiline.comma_dangle": false,
    "array.multiline.element_count": 4,
    "array.multiline.leading_comma": false,
    "array.multiline.leading_comma.padding": true,
    "array.multiline.min_length": 40,
    "array.padding": false,
    "function_call.casing.builtin": "cfdocs",
    "newline": "os",
    "parentheses.padding": false
}

```

